### PR TITLE
Fix documentation

### DIFF
--- a/docsrc/Makefile
+++ b/docsrc/Makefile
@@ -15,6 +15,7 @@ help:
 
 github:
 	@make html
+	@touch _build/html/.nojekyll
 	@cp -a _build/html/. ../docs
 
 # Catch-all target: route all unknown targets to Sphinx using the new


### PR DESCRIPTION
This PR fixes the documentation issue regarding the missing `.nojekyll` file after the last PR (see the [documentation](https://fmr-llc.github.io/mabwiser/)). It also automates the creation of the `.nojekyll` file so this doesn't happen again.